### PR TITLE
Fixes 02052021

### DIFF
--- a/src/pages/Detail/index.js
+++ b/src/pages/Detail/index.js
@@ -89,7 +89,7 @@ export const Detail = () => {
       } else if (status === 202) {
         const retryMs = headers['retry-after']
         if (data.user) setUser(data.user)
-        if (data.systems) setSystems(data.systems.filter(system => system !== 'vigobas'))
+        if (data.systems) setSystems(data.systems)
         setTimeout(getReport, retryMs)
       }
     }

--- a/src/pages/Detail/index.js
+++ b/src/pages/Detail/index.js
@@ -291,6 +291,14 @@ export const Detail = () => {
                       open &&
                         <div className='result-table-row-detail'>
                           {
+                            item.error &&
+                            <div className='result-table-row-detail-error'>
+                              <Paragraph><strong>Feil</strong>: {item.error.error}</Paragraph>
+                            </div>
+                          }
+
+                          {
+                            item.data &&
                             item.errorCount > 0 &&
                             item.errorTests.map((testItem, index) => {
                               return (
@@ -306,6 +314,7 @@ export const Detail = () => {
                           }
 
                           {
+                            item.data &&
                             item.warningCount > 0 &&
                             item.warningTests.map((testItem, index) => {
                               return (
@@ -321,6 +330,7 @@ export const Detail = () => {
                           }
 
                           {
+                            item.data &&
                             item.okCount > 0 &&
                             item.okTests.map((testItem, index) => {
                               return (
@@ -336,6 +346,7 @@ export const Detail = () => {
                           }
 
                           {
+                            item.data &&
                             item.errorCount === 0 &&
                             item.warningCount === 0 &&
                             item.okCount === 0 &&

--- a/src/pages/Detail/index.js
+++ b/src/pages/Detail/index.js
@@ -31,6 +31,7 @@ export const Detail = () => {
   const [loading, setLoading] = useState(true)
   const [expandedItemIndex, setExpandedItemIndex] = useState(null)
   const [modalOpen, setModalOpen] = useState(false)
+  const [resultError, setResultError] = useState(null)
   const [results, setResults] = useState(null)
   const [user, setUser] = useState(null)
   const [systems, setSystems] = useState(null)
@@ -67,7 +68,20 @@ export const Detail = () => {
         }
       })
 
-      if (status === 200) {
+      if (data === undefined && headers === undefined && status === undefined) {
+        // something went wrong
+        setLoading(false)
+        setResultError('Noe gikk galt. Siden kan ikke vises')
+        setResults(null)
+        setUser({
+          givenName: 'Not',
+          surName: 'Available',
+          displayName: 'Ikke tilgjengelig',
+          userPrincipalName: 'ikke.tilgjengelig@vtfk.no',
+          samAccountName: 'ikk4242',
+          office: 'Syndebukk'
+        })
+      } else if (status === 200) {
         setLoading(false)
         setVigoBasStamp(prettifyDate(new Date(data.vigobas.lastRunTime)))
         normalizeAndSetResults(data.data)
@@ -351,6 +365,13 @@ export const Detail = () => {
                 <Heading4 className='info-timestamp'>
                   <strong>Siste kjøring av VigoBas:</strong> {vigoBasStamp}
                 </Heading4>
+            }
+
+            {
+              !loading &&
+              !results &&
+              resultError &&
+                <Heading3>{resultError}</Heading3>
             }
           </div>
         </div>


### PR DESCRIPTION
- Lagt til en visning når noe går galt ved henting/generering av rapport i backend (4xx/5xx)

- Lagt til visning når et system failer i backend (closes #61 )

- NonSystems blir filtrert ut i API'et før det sendes til FrontEnd. Derfor er filtreringen av NonSystems i FrontEnd fjernet her. `Oppdatering i databasen må gjøres før denne endringen merges for å unngå at tidligere rapporter viser NonSystems`