### PR TITLE
Skjul "tøm søkefeltet"-knappen når søkefeltet er tomt

### DIFF
--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -126,6 +126,8 @@ export function Layout (props) {
             <SearchField
               onChange={e => onChanged(e.target.value)}
               onSearch={e => search(e.target.value)}
+              onClear={() => setQuery('')}
+              showClear={!!query}
               debounceMs={1000}
               onSelected={value => generateReport(value)}
               autocomplete={false}


### PR DESCRIPTION
Skjuler knappen for å tømme søkefeltet når det ikke står noe der, eller det allerede er tømt 🗑️